### PR TITLE
Add all optional dependency extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.9.10
+
+### Added
+
+- A `sparclur[all]` extra that installs the UI, native report PDF support, and
+  every supported Python-backed parser adapter.
+
 ## 2026.9.9
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Python-backed parser adapters and Streamlit interface are intentionally
 optional. Install only what you plan to use:
 
 ```bash
+pip install --upgrade "sparclur[all]"     # Every supported optional feature
 pip install "sparclur[mupdf]"             # PyMuPDF adapter
 pip install "sparclur[pdfium]"            # PDFium adapter
 pip install "sparclur[pdfminer]"          # PDFMiner adapter
@@ -236,14 +237,15 @@ documented by the [WeasyPrint installation guide](https://doc.courtbouillon.org/
 
 ### PyPI installation
 
-Install the optional UI dependencies and run the packaged command:
+Install every supported optional feature, including the UI, and run the packaged command:
 
 ```bash
-pip install "sparclur[ui]"
+pip install --upgrade "sparclur[all]"
 sparclur-ui
 ```
 
-Add a parser adapter as needed, for example `pip install "sparclur[ui,mupdf,pdfium]"`.
+For a smaller install, use the UI extra alone or combine it with specific parser
+extras, for example `pip install "sparclur[ui,mupdf,pdfium]"`.
 
 The command launches a Streamlit web app for exploring uploaded PDFs with the
 PTC, PRC, PXC, Metadata, and Raw views. It accepts standard Streamlit options,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sparclur"
-version = "2026.9.9"
+version = "2026.9.10"
 description = "Tools for analyzing PDF files and comparing PDF parsers"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -51,6 +51,13 @@ ui = ["streamlit>=1.40"]
 mupdf = ["PyMuPDF>=1.24"]
 pdfium = ["pypdfium2>=5.0"]
 pdfminer = ["pdfminer.six>=20240706"]
+all = [
+    "weasyprint>=70",
+    "streamlit>=1.40",
+    "PyMuPDF>=1.24",
+    "pypdfium2>=5.0",
+    "pdfminer.six>=20240706",
+]
 dev = [
     "build>=1.2",
     "pytest>=8.3",

--- a/sparclur/__init__.py
+++ b/sparclur/__init__.py
@@ -5,7 +5,7 @@ from ._roll_back import RollBack
 from ._floodlight import FloodLight
 from ._reports import BatchReport, DocumentReport, SparclurReport
 
-__version__ = '2026.9.9'
+__version__ = '2026.9.10'
 
 __all__ = [
     "Astrotruther",


### PR DESCRIPTION
## Summary
- Add sparclur[all] for every supported user-facing optional dependency.
- Document the one-command installation path.
- Advance the date-based version to 2026.9.10 for a publishable release.

## Verification
- Focused report and UI CLI tests passed.
- Ruff passed.
- sdist and wheel build passed.
- Twine checks and all-extra wheel metadata validation passed.